### PR TITLE
fix: ISRキャッシュを削除してデータを常に最新に保つ

### DIFF
--- a/app/category/[id]/page.tsx
+++ b/app/category/[id]/page.tsx
@@ -12,7 +12,7 @@ interface CategoryPageProps {
   params: Promise<{ id: string }>
 }
 
-export const revalidate = 3600
+export const revalidate = 0
 
 export async function generateStaticParams() {
   const supabase = createStaticClient()

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -3,7 +3,7 @@ import { createStaticClient } from "@/lib/supabase/static"
 import DashboardClient from "./dashboard-client"
 import type { Category } from "@/lib/training-data"
 
-export const revalidate = 3600
+export const revalidate = 0
 
 export default async function DashboardPage() {
   const supabase = createStaticClient()

--- a/app/training/[id]/page.tsx
+++ b/app/training/[id]/page.tsx
@@ -17,7 +17,7 @@ interface TrainingPageProps {
   params: Promise<{ id: string }>
 }
 
-export const revalidate = 3600
+export const revalidate = 0
 
 export async function generateStaticParams() {
   const supabase = createStaticClient()

--- a/app/training/[id]/session/page.tsx
+++ b/app/training/[id]/session/page.tsx
@@ -9,7 +9,7 @@ import { Footer } from "@/components/footer"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 
-export const revalidate = 3600
+export const revalidate = 0
 
 export async function generateStaticParams() {
   const supabase = createStaticClient()


### PR DESCRIPTION
## 概要

ページのISRキャッシュ (`revalidate = 3600`) を削除し、毎回のリクエストでデータを再取得するようにしました。

## 変更内容

- `app/dashboard/page.tsx`
- `app/category/[id]/page.tsx`
- `app/training/[id]/page.tsx`
- `app/training/[id]/session/page.tsx`

これらのページで `revalidate = 0` に変更しました。

## 理由

問題データやカテゴリ情報が1時間キャッシュされていたため、修正後の反映が遅れていました。
常に最新のデータを表示するため、キャッシュを無効化します。

## 注意

本番環境でのパフォーマンスを考慮して、将来的に適切なキャッシュ値（例：60秒など）に戻す必要があります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)